### PR TITLE
[DayCountR] 开服天数 - 重制版（外加链接更新）

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,8 @@ If there is any good plugin, please submit a PR, and I will invite you to this o
 | [Online](https://github.com/A-JiuA/Online) | [A-JiuA](https://github.com/A-JiuA) | A plugin for querying online players of several servers |
 | [seed](https://github.com/ChunkAsgore/seed) | [ChunkAsgore](https://github.com/ChunkAsgore) | A plugin for querying server map seeds for MCDReforged. |
 | [Info](https://github.com/zhang-anzhi/MCDReforgedPlugins/tree/master/Info) | [zhang_anzhi](https://github.com/zhang-anzhi) | Get useful server info(CPU/memory/world size...) |
-| [SeedR](https://github.com/Van-Involution/MCDR-Plugins) | [Van_Involution](https://github.com/Van-Involution) | Use `!!seed` to get seed, be reforged to apply to MCDR 1.x, reply translated message just like vanilla style |
+| [SeedR](https://github.com/Van-Involution/SeedR) | [Van_Involution](https://github.com/Van-Involution) | Use `!!seed` to get seed, be reforged to apply to **MCDR-v1.x**, reply translated message just like vanilla style |
+| [DayCountR](https://github.com/Van-Involution/DayCountR) | [Van_Involution](https://github.com/Van-Involution) | Use `!!days` to get day count since server set up, be reforged to apply to **MCDR-v1.x**, customize **start day** and **reply msg** by config file |
 
 ### Search
 

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -27,7 +27,8 @@
 | [Online](https://github.com/A-JiuA/Online) | [A-JiuA](https://github.com/A-JiuA) | 查询多个服务器的玩家在线情况并在玩家登入时提示 |
 | [seed](https://github.com/ChunkAsgore/seed) | [ChunkAsgore](https://github.com/ChunkAsgore) | 适用于MCDReforged的用于查询服务器地图种子的插件。 |
 | [Info](https://github.com/zhang-anzhi/MCDReforgedPlugins/tree/master/Info) | [zhang_anzhi](https://github.com/zhang-anzhi) | 获取有用的服务器信息(CPU/内存/存档大小等) |
-| [SeedR](https://github.com/Van-Involution/MCDR-Plugins) | [Van_Involution](https://github.com/Van-Involution) | 使用`!!seed`获取种子，经过重制以适配MCDR 1.x，回复具有原版风格并经过翻译的消息 |
+| [SeedR](https://github.com/Van-Involution/SeedR) | [Van_Involution](https://github.com/Van-Involution) | 使用`!!seed`获取种子，经过重制以适配**MCDR-v1.x**，回复具有原版风格并经过翻译的消息 |
+| [DayCountR](https://github.com/Van-Involution/DayCountR) | [Van_Involution](https://github.com/Van-Involution) | 使用`!!days`获取开服天数，经过重制以适配**MCDR-v1.x**，通过配置文件自定义开服日期和回复消息 |
 
 ### 搜索
 


### PR DESCRIPTION
### 本次提交的修改

- 新增插件：**[DayCountR](https://github.com/Van-Involution/DayCountR)**
  - 重制自 **[Fallen_Breath](https://github.com/Fallen-Breath)** 的 **[daycount](https://github.com/TISUnion/daycount)**，适配**MCDR-v1.x**
  - 使用`!!day`获取开服天数，通过配置文档`plugins/DayCountR.yml`自定义**开服日期**和**回复消息**

- 更新 **[SeedR](https://github.com/Van-Involution/SeedR)** 的链接至正确的仓库
