### PR TITLE
添加Notice公告插件

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,7 @@ If there is any good plugin, please submit a PR, and I will invite you to this o
 | [ANN](https://github.com/Da-Dog/MCDR-Plugins/tree/master/MCDR_ANN) | [Da_Dog](https://github.com/Da-Dog) | Timed announcement |
 | [CustomMOTD](https://github.com/GamerNoTitle/CustomMOTD) | [GamerNoTitle](https://github.com/GamerNoTitle) | Change your MOTD with a command(colorful content is supported) |
 | [JoinMOTDR](https://github.com/Van-Involution/JoinMOTDR) | [Van_Involution](https://github.com/Van-Involution) | Send MOTD on player joined, can **deeply customize** by config file (**MCDR 1.x Only**) |
+| [Notice](https://github.com/LiamSho/MCDReforgedPlugins/tree/main/Notice) | [LiamSho](https://github.com/LiamSho) | Easy-to-use announcement plugin. Multiple announcements, auto send on joining, manually broadcast, etc. (**MCDR 1.x Only**) |
 
 ### Files
 

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -140,6 +140,7 @@
 | [ANN](https://github.com/Da-Dog/MCDR_ANN) | [Da_Dog](https://github.com/Da-Dog) | 定时公告 |
 | [CustomMOTD](https://github.com/GamerNoTitle/CustomMOTD) | [GamerNoTitle](https://github.com/GamerNoTitle) | 使用命令来修改服务器的MOTD（支持颜色代码） |
 | [JoinMOTDR](https://github.com/Van-Involution/JoinMOTDR) | [Van_Involution](https://github.com/Van-Involution) | 玩家加入服务器时显示可通过配置文件**深度自定义**的信息（**仅支持MCDR 1.x**） |
+| [Notice](https://github.com/LiamSho/MCDReforgedPlugins/tree/main/Notice) | [LiamSho](https://github.com/LiamSho) | 简单易用的公告插件，可以创建多条公告，设置玩家加入时发送，手动全服广播等（**仅支持MCDR 1.x**） |
 
 ### 文件管理
 


### PR DESCRIPTION
添加Notice公告插件
[文档](https://github.com/LiamSho/MCDReforgedPlugins/blob/main/Notice)        

## 插件依赖
* mcdreforged >= 1.0.0
* online_player_api = *
## 功能
* 通过指令或者配置文件设置公告标题和内容（最终输出为 标题：内容 的格式）
* 通过指令或者配置文件删除公告
* 通过指令或者配置文件设置公告框大标题
* 通过指令或者配置文件开启或关闭玩家进入服务器时自动发送的功能
* 通过指令向全服在线玩家广播公告