### PR TITLE
Add some plugins

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -250,6 +250,7 @@ The official plugin manager will be released after the release of MCDR 2.0. Plea
 | [MoreAPIs](https://github.com/HuajiMUR233/MoreAPIs) | [Huaji_MUR233](https://github.com/HuajiMUR233) | A very simple plugin that provides some (secondary wrapper) API with events |
 | [PythonIsPlugin](https://github.com/HuajiMUR233/PythonIsPlugin) | [Huaji_MUR233](https://github.com/HuajiMUR233) | Let you can depend a you want python version |
 | [MCDReforged-Remote](https://github.com/iXORTech/MCDReforged-Remote) | [Cubik65536](https://github.com/Cubik65536) | A MCDR plugin and a Java library, connecting QQ and Minecraft & allowing users to implement server control and other functions through the library  |
+| [MoreAPIs](https://github.com/Harry-zklcdc/MCDR-Plugins/tree/main/MoreAPIs) | [Harry-zklcdc](https://github.com/Harry-zklcdc) | Provides some (secondary wrapper) API with events, and fix some bugs |
 
 ## Bukkit Revolution
 

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,7 @@ If there is any good plugin, please submit a PR, and I will invite you to this o
 | [LocationMarker](https://github.com/TISUnion/LocationMarker) | [Fallen_Breath](https://github.com/Fallen-Breath) | A server side waypoint manager |
 | [Where](https://github.com/Ivan-YFw/MCDReforged-Plugins/tree/master/where) | [IvanYF](https://github.com/Ivan-YFw) | Check the coordinate of a player |
 | [Markit](https://github.com/mrxiaozhuox/Markit) | [mrxiaozhuox](https://github.com/mrxiaozhuox) | Create, share and manage Your coordinates! |
+| [DiePosition](https://github.com/Harry-zklcdc/MCDR-Plugins/tree/main/DiePos) | [Harry-zklcd](https://github.com/Harry-zklcdc) | Send player death position to the position owner && Support MCDR1.x |
 
 ### Scoreboard
 

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ If there is any good plugin, please submit a PR, and I will invite you to this o
 | [Bot](https://github.com/zhang-anzhi/MCDReforgedPlugins/tree/master/Bot) | [zhang_anzhi](https://github.com/zhang-anzhi) | Storage bot list, one key to spawn or kill bot |
 | [BotMono](https://github.com/Jerry-FaGe/MCDR-BotMono) | [Jerry-FaGe](https://github.com/Jerry-FaGe) | The input English, Chinese (even Pinyin) points to the same BOT and provides operation interface and simplified instructions |
 | [BotKikai](https://github.com/Jerry-FaGe/MCDR-BotKikai) | [Jerry-FaGe](https://github.com/Jerry-FaGe) | Storage bot position list, one key to spawn or kill bot, and can let the bot right click |
+| [MCDR_bot](https://github.com/Harry-zklcdc/MCDR-Plugins/tree/main/MCDR_Bot) | [Harry-zklcdc](https://github.com/Harry-zklcdc) | Fake player support based on [pycraft](https://github.com/ammaraskar/pyCraft), Supoort to `1.16.4` and yourself `Yggdrasil API` |
 
 ### Command
 

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ If there is any good plugin, please submit a PR, and I will invite you to this o
 | [LocationMarker](https://github.com/TISUnion/LocationMarker) | [Fallen_Breath](https://github.com/Fallen-Breath) | A server side waypoint manager |
 | [Where](https://github.com/Ivan-YFw/MCDReforged-Plugins/tree/master/where) | [IvanYF](https://github.com/Ivan-YFw) | Check the coordinate of a player |
 | [Markit](https://github.com/mrxiaozhuox/Markit) | [mrxiaozhuox](https://github.com/mrxiaozhuox) | Create, share and manage Your coordinates! |
-| [DiePosition](https://github.com/Harry-zklcdc/MCDR-Plugins/tree/main/DiePos) | [Harry-zklcd](https://github.com/Harry-zklcdc) | Send player death position to the position owner && Support MCDR1.x |
+| [DiePosition](https://github.com/Harry-zklcdc/MCDR-Plugins/tree/main/DiePos) | [Harry-zklcdc](https://github.com/Harry-zklcdc) | Send player death position to the position owner && Support `MCDR1.x` |
 
 ### Scoreboard
 

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -250,6 +250,7 @@
 | [MoreAPIs](https://github.com/HuajiMUR233/MoreAPIs) | [Huaji_MUR233](https://github.com/HuajiMUR233) | 一个非常简单的插件，提供了一些(二次封装的)API与事件 |
 | [PythonIsPlugin](https://github.com/HuajiMUR233/PythonIsPlugin) | [Huaji_MUR233](https://github.com/HuajiMUR233) | \现在你可以依赖你想要的 Python 版本了/ |
 | [MCDReforged-Remote](https://github.com/iXORTech/MCDReforged-Remote) | [Cubik65536](https://github.com/Cubik65536) | 一个MCDR插件+Java库，允许用户通过该库实现QQ，MC双向聊天，服务器控制等功能 |
+| [MoreAPIs](https://github.com/Harry-zklcdc/MCDR-Plugins/tree/main/MoreAPIs) | [Harry-zklcdc](https://github.com/Harry-zklcdc) | 提供了更多的API, 并对原插件进行bug修复 |
 
 ## 水桶革命
 

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -52,7 +52,7 @@
 | [LocationMarker](https://github.com/TISUnion/LocationMarker) | [Fallen_Breath](https://github.com/Fallen-Breath) | 一个服务端共享路标点管理器 |
 | [Where](https://github.com/Ivan-YFw/MCDReforged-Plugins/tree/master/where) | [IvanYF](https://github.com/Ivan-YFw) | 查看其他玩家的坐标 |
 | [Markit](https://github.com/mrxiaozhuox/Markit) | [mrxiaozhuox](https://github.com/mrxiaozhuox) | 保存、共享、管理坐标，分享自己的坐标！ |
-| [DiePosition](https://github.com/Harry-zklcdc/MCDR-Plugins/tree/main/DiePos) | [Harry-zklcd](https://github.com/Harry-zklcdc) | Send player death position to the position owner && Support MCDR1.x |
+| [DiePosition](https://github.com/Harry-zklcdc/MCDR-Plugins/tree/main/DiePos) | [Harry-zklcdc](https://github.com/Harry-zklcdc) | 玩家死亡私发死亡坐标 && 支持 `MCDR1.x` |
 
 ### 计分板
 

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -96,6 +96,7 @@
 | [Bot](https://github.com/zhang-anzhi/MCDReforgedPlugins/tree/master/Bot) | [zhang_anzhi](https://github.com/zhang-anzhi) | 存储机器人列表，一键放置/清除机器人 |
 | [BotMono](https://github.com/Jerry-FaGe/MCDR-BotMono) | [Jerry-FaGe](https://github.com/Jerry-FaGe) | 假人物品映射：将输入的英文，中文（甚至拼音）指向同一假人并提供操作界面和简化指令的插件 |
 | [BotKikai](https://github.com/Jerry-FaGe/MCDR-BotKikai) | [Jerry-FaGe](https://github.com/Jerry-FaGe) | 假人器械映射：储存假人的位置信息，随时随地一键放置/清除假人，并可以让假人右键|
+| [MCDR_bot](https://github.com/Harry-zklcdc/MCDR-Plugins/tree/main/MCDR_Bot) | [Harry-zklcdc](https://github.com/Harry-zklcdc) | 使用 [pycraft](https://github.com/ammaraskar/pyCraft) 的假人插件, 支持 `1.16.4` 和自建 `Yggdrasil API` |
 
 ### 指令助手
 

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -52,6 +52,7 @@
 | [LocationMarker](https://github.com/TISUnion/LocationMarker) | [Fallen_Breath](https://github.com/Fallen-Breath) | 一个服务端共享路标点管理器 |
 | [Where](https://github.com/Ivan-YFw/MCDReforged-Plugins/tree/master/where) | [IvanYF](https://github.com/Ivan-YFw) | 查看其他玩家的坐标 |
 | [Markit](https://github.com/mrxiaozhuox/Markit) | [mrxiaozhuox](https://github.com/mrxiaozhuox) | 保存、共享、管理坐标，分享自己的坐标！ |
+| [DiePosition](https://github.com/Harry-zklcdc/MCDR-Plugins/tree/main/DiePos) | [Harry-zklcd](https://github.com/Harry-zklcdc) | Send player death position to the position owner && Support MCDR1.x |
 
 ### 计分板
 


### PR DESCRIPTION
我 魔改 的一些插件

## DiePos

私发玩家死亡坐标 (需要 [MinecraftDataAPI](https://github.com/MCDReforged/MinecraftDataAPI) and [MoreAPIs](/tree/main/MoreAPIs))

感谢 [@57767598](https://github.com/577fkj/) 开发的`DiePos`插件和[@Fallen_Breath](https://github.com/Fallen-Breath) 开发的`Here`插件，本插件对其进行了`MCDR 1.x`的适配，使其可在`MCDR 1.x`下使用

## MoreAPIs

更多的API

感谢 [@Huaji_MUR233](https://github.com/HuajiMUR233) 开发的`MoreAPIs`插件，本插件对其进行了bug修复

## MCDR_Bot

 使用 [pycraft](https://github.com/ammaraskar/pyCraft) 的假人插件，支持自建Yggdrasil API

感谢 [@Fallen_Breath](https://github.com/Fallen-Breath) 开发的`MCDR-bot`插件，本插件升级了`pycraft`，支持`Minecraft Java 1.8-1.16.4`，