### PR TITLE
Multi page releases support (fix #239)

### DIFF
--- a/scripts/plugin.py
+++ b/scripts/plugin.py
@@ -115,7 +115,7 @@ class ReleaseSummary(Serializable):
 				break
 		if all_resp:
 			self.releases = []
-			for item in resp:
+			for item in all_resp:
 				item['url'] = item['html_url']
 				item['description'] = item['body'] or 'N/A'
 				try:

--- a/scripts/plugin.py
+++ b/scripts/plugin.py
@@ -97,7 +97,7 @@ class ReleaseSummary(Serializable):
 	releases: List[ReleaseInfo]
 
 	def fetch_from_api(self, plugin: 'Plugin'):
-		per_page: int = 1
+		per_page: int = 100
 		page: int = 1
 		url = f'https://api.github.com/repos/{plugin.repos_path}/releases?per_page={per_page}&page={{}}'
 		all_resp: List[dict] = []


### PR DESCRIPTION
已知问题：对于多插件 repo，每个插件检查时都会重新获取该 repo Releases 的每一页，有点浪费 API 使用次数