### PR TITLE
Add PR Template & Checklist Workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,31 @@
+
+<!-- 在上方撰写您想附加的信息 -->
+<!-- Write your own things above -->
+
+---
+
+## 检查以下事项 | Check the following:
+
+<!--
+- 请检查确认后勾选最下方的复选框，不要修改其它内容
+  After checking the following, tick the checkbox at end. DO NOT MODIFY ANY OTHER CONTENT
+- 勾选案例：- [x] ...
+  Ticked checkbox sample: - [x] ...
+-->
+<!--Checkmate-->
+
+- 仓库 URL、分支和 `related_path` 正确且 `mcdreforged.plugin.json` 位于应当存在的位置
+  Repository URL, branch and `related_path` are correct and `mcdreforged.plugin.json` file exists at the correct path
+
+- 根据 [文档](https://mcdreforged-docs-zh-cn.rtfd.io/plugin_dev/plugin_catalogue.html#label)，检查插件标签正确且合适  
+  Plugin labels are correct and appropriate according to [documentation](https://mcdreforged-docs.rtfd.io/plugin_dev/plugin_catalogue.html#label)
+
+- 确保 `mcdreforged.plugin.json` 和 `plugin_info.json` 中的插件 ID 与在本仓库创建的文件夹名称一致
+  Plugin ID in `mcdreforged.plugin.json` and `plugin_info.json` match the name of the folder created in this repository
+
+- 在介绍中简要阐明插件功能，在 README 中详细阐明插件用法，避免含糊不清。确保潜在用户有理由考虑使用您的插件
+  Briefly clarify plugin features in the introduction, and clarify plugin usage in detail in the README. Avoid vague descriptions. Ensure that potential users have a reason to consider using your plugin
+
+<!--Checkmate-->
+- [ ] 我已检查并确认以上所有项目
+  I have checked and confirmed all the above

--- a/.github/workflows/checklist.yml
+++ b/.github/workflows/checklist.yml
@@ -1,0 +1,31 @@
+name: Checklist Validate
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'plugins/**'
+    types: [edited, opened, reopened]
+
+jobs:
+  checklists:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Auto comment
+        uses: wow-actions/auto-comment@v1
+        if: ${{ github.event.action == 'opened' }}
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pullRequestOpened: |
+            ## 合并前检查单
+            感谢您的贡献。请等待插件仓库维护者检查您的插件。以下是供仓库维护者参考的合并前检查单。
+            - [ ] 插件名称符合其功能、没有歧义
+            - [ ] 仓库属于提交者本人或本人为仓库维护者
+            - [ ] 分类正确
+            - [ ] 应当有可阅读插件说明，且内容足以帮助用户使用
+            - [ ] 若使用了插件仓库文件作为介绍，文件应当有效，检查时应当注意相对路径
+            - [ ] 其他应当检查并予以合并或不合并的情况
+      - name: Validate checklists
+        uses: roryq/checkmate@master

--- a/.github/workflows/plugin_check.yml
+++ b/.github/workflows/plugin_check.yml
@@ -1,4 +1,4 @@
-name: PR Check
+name: Plugin Check
 
 on:
   pull_request:
@@ -6,32 +6,11 @@ on:
       - master
     paths:
       - 'plugins/**'
-    types: [edited, opened, reopened, synchronize]
+    types: [opened, synchronize]
 
 jobs:
-  checklists:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Auto comment
-        uses: wow-actions/auto-comment@v1
-        if: ${{ github.event.action == 'opened' }}
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          pullRequestOpened: |
-            ## 合并前检查单
-            感谢您的贡献。请等待插件仓库维护者检查您的插件。以下是供仓库维护者参考的合并前检查单。
-            - [ ] 插件名称符合其功能、没有歧义
-            - [ ] 仓库属于提交者本人或本人为仓库维护者
-            - [ ] 分类正确
-            - [ ] 应当有可阅读插件说明，且内容足以帮助用户使用
-            - [ ] 若使用了插件仓库文件作为介绍，文件应当有效，检查时应当注意相对路径
-            - [ ] 其他应当检查并予以合并或不合并的情况
-      - name: Validate checklists
-        uses: roryq/checkmate@master
   plugin-check:
     runs-on: ubuntu-latest
-    if: ${{ github.event.action == 'opened' || github.event.action == 'synchronize' }}
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -12,10 +12,7 @@ jobs:
   checklists:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Validate checklists
-        uses: roryq/checkmate@master
+      - uses: actions/checkout@v3
       - name: Auto comment
         uses: wow-actions/auto-comment@v1
         if: ${{ github.event.action == 'opened' }}
@@ -30,9 +27,10 @@ jobs:
             - [ ] 应当有可阅读插件说明，且内容足以帮助用户使用
             - [ ] 若使用了插件仓库文件作为介绍，文件应当有效，检查时应当注意相对路径
             - [ ] 其他应当检查并予以合并或不合并的情况
+      - name: Validate checklists
+        uses: roryq/checkmate@master
   plugin-check:
     runs-on: ubuntu-latest
-    needs: checklists
     if: ${{ github.event.action == 'opened' || github.event.action == 'synchronize' }}
     steps:
       - uses: actions/checkout@v3
@@ -71,4 +69,4 @@ jobs:
           done
           
         env:
-          github_api_token: ${{ secrets.TOKEN_FOR_GITHUB_API }}  
+          github_api_token: ${{ secrets.TOKEN_FOR_GITHUB_API }}

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -4,9 +4,12 @@ on:
   pull_request:
     branches:
       - master
+    paths:
+      - 'plugins/**'
+    types: [edited, opened, reopened, synchronize]
 
 jobs:
-  check:
+  basic-check:
     runs-on: ubuntu-latest
 
     steps:
@@ -47,3 +50,25 @@ jobs:
           
         env:
           github_api_token: ${{ secrets.TOKEN_FOR_GITHUB_API }}
+      
+  checklists:
+    runs-on: ubuntu-latest
+    needs: basic-check
+    steps:
+      - uses: actions/checkout@v3
+      - name: Validate checklists
+        uses: roryq/checkmate@master
+      - name: Auto comment
+        uses: wow-actions/auto-comment@v1
+        if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pullRequestOpened: |
+            ## 合并前检查单
+            感谢您的贡献。请等待插件仓库维护者检查您的插件。以下是供仓库维护者参考的合并前检查单。
+            - [ ] 插件名称符合其功能、没有歧义
+            - [ ] 仓库属于提交者本人或本人为仓库维护者
+            - [ ] 分类正确
+            - [ ] 应当有可阅读插件说明，且内容足以帮助用户使用
+            - [ ] 若使用了插件仓库文件作为介绍，文件应当有效，检查时应当注意相对路径
+            - [ ] 其他应当检查并予以合并或不合并的情况

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -9,9 +9,30 @@ on:
     types: [edited, opened, reopened, synchronize]
 
 jobs:
-  basic-check:
+  checklists:
     runs-on: ubuntu-latest
-
+    steps:
+      - uses: roryq/checkmate@master
+      - name: Auto comment
+        uses: wow-actions/auto-comment@v1
+        if: ${{ github.event.action == 'opened' }}
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pullRequestOpened: |
+            ## 合并前检查单
+            感谢您的贡献。请等待插件仓库维护者检查您的插件。以下是供仓库维护者参考的合并前检查单。
+            - [ ] 插件名称符合其功能、没有歧义
+            - [ ] 仓库属于提交者本人或本人为仓库维护者
+            - [ ] 分类正确
+            - [ ] 应当有可阅读插件说明，且内容足以帮助用户使用
+            - [ ] 若使用了插件仓库文件作为介绍，文件应当有效，检查时应当注意相对路径
+            - [ ] 其他应当检查并予以合并或不合并的情况
+      - name: Validate checklists
+        uses: actions/checkout@v3
+  plugin-check:
+    runs-on: ubuntu-latest
+    needs: checklists
+    if: ${{ github.event.action == 'opened' || github.event.action == 'synchronize' }}
     steps:
       - uses: actions/checkout@v3
 
@@ -49,26 +70,4 @@ jobs:
           done
           
         env:
-          github_api_token: ${{ secrets.TOKEN_FOR_GITHUB_API }}
-      
-  checklists:
-    runs-on: ubuntu-latest
-    needs: basic-check
-    steps:
-      - uses: actions/checkout@v3
-      - name: Validate checklists
-        uses: roryq/checkmate@master
-      - name: Auto comment
-        uses: wow-actions/auto-comment@v1
-        if: ${{ github.event_name == 'pull_request' && github.event.action == 'opened' }}
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          pullRequestOpened: |
-            ## 合并前检查单
-            感谢您的贡献。请等待插件仓库维护者检查您的插件。以下是供仓库维护者参考的合并前检查单。
-            - [ ] 插件名称符合其功能、没有歧义
-            - [ ] 仓库属于提交者本人或本人为仓库维护者
-            - [ ] 分类正确
-            - [ ] 应当有可阅读插件说明，且内容足以帮助用户使用
-            - [ ] 若使用了插件仓库文件作为介绍，文件应当有效，检查时应当注意相对路径
-            - [ ] 其他应当检查并予以合并或不合并的情况
+          github_api_token: ${{ secrets.TOKEN_FOR_GITHUB_API }}  

--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -12,7 +12,10 @@ jobs:
   checklists:
     runs-on: ubuntu-latest
     steps:
-      - uses: roryq/checkmate@master
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Validate checklists
+        uses: roryq/checkmate@master
       - name: Auto comment
         uses: wow-actions/auto-comment@v1
         if: ${{ github.event.action == 'opened' }}
@@ -27,8 +30,6 @@ jobs:
             - [ ] 应当有可阅读插件说明，且内容足以帮助用户使用
             - [ ] 若使用了插件仓库文件作为介绍，文件应当有效，检查时应当注意相对路径
             - [ ] 其他应当检查并予以合并或不合并的情况
-      - name: Validate checklists
-        uses: actions/checkout@v3
   plugin-check:
     runs-on: ubuntu-latest
     needs: checklists


### PR DESCRIPTION
## What workflow does
- It runs only when someone opened a PR modifying files in `plugins` folder
- Auto add a cmoment for catalogue maintainers:
  ![image](https://user-images.githubusercontent.com/45303195/221214488-a374b536-2dd1-4c43-af82-fc1fec5baed1.png)
- If the check box in PR template didn't ticked, it fails
- When contributor open or commit a PR, run plugin-check script for basic checks
