### PR TITLE
remove `information` label of loginproxy

### DIFF
--- a/plugins/loginproxy/plugin_info.json
+++ b/plugins/loginproxy/plugin_info.json
@@ -7,5 +7,5 @@
     "repository": "https://github.com/kmcsr/login_proxy_mcdr",
     "branch": "master",
     "related_path": ".",
-    "labels": ["management", "information", "api"]
+    "labels": ["management", "api"]
 }


### PR DESCRIPTION
> Show or get information for users

该插件并不能提供真正意义上的 useful 信息，白名单信息不应当被认为符合信息分类的定义
