### PR TITLE
Updated `mcd_seen` repository branch to `master`

### DIFF
--- a/plugins/mcd_seen/plugin_info.json
+++ b/plugins/mcd_seen/plugin_info.json
@@ -15,6 +15,6 @@
 		}
 	],
 	"repository": "https://github.com/TISUnion/Seen",
-	"branch": "MCDR",
+	"branch": "master",
 	"labels": ["tool"]
 }


### PR DESCRIPTION
Plugin `mcd_seen` changed default branch  to `master` and this update is required

<!-- 在上方撰写您想附加的信息 -->
<!-- Write your own things above -->

<!-- 如果你不是为了添加插件入库，请删除下方所有内容 -->
<!-- Delete all the content below if you're not adding your plugin to the catalogue -->
