### PR TITLE
workflow: 引入reporter信息

### DIFF
--- a/.github/workflows/scripts/pr_check.py
+++ b/.github/workflows/scripts/pr_check.py
@@ -43,12 +43,11 @@ async def main():
 	reporter.record_script_start()
 	reporter.record_command('pr_check')
 
-	plugin_list = []
+	plugin_list = get_plugin_list(target_ids)
 	
 	if not target_ids:
 		reporter.record_script_failure(ValueError("Empty plugin list"))
 	else:
-		plugin_list = get_plugin_list(target_ids)
 		await plugin_list.fetch_data(fail_hard=False, skip_release=True)
 		
 	reporter.report(plugin_list)

--- a/.github/workflows/scripts/pr_check.py
+++ b/.github/workflows/scripts/pr_check.py
@@ -7,12 +7,12 @@ import logging
 import os
 import sys
 
+sys.path.append('scripts')
+
 from common.constants import REPOS_ROOT
 from common.log import logger
 from common.report import reporter
 from plugin.plugin_list import get_plugin_list
-
-sys.path.append('scripts')
 
 
 logger.setLevel(logging.INFO)

--- a/.github/workflows/scripts/pr_check.py
+++ b/.github/workflows/scripts/pr_check.py
@@ -42,6 +42,8 @@ async def main():
 
 	reporter.record_script_start()
 	reporter.record_command('pr_check')
+
+	plugin_list = []
 	
 	if not target_ids:
 		reporter.record_script_failure(ValueError("Empty plugin list"))
@@ -49,7 +51,7 @@ async def main():
 		plugin_list = get_plugin_list(target_ids)
 		await plugin_list.fetch_data(fail_hard=False, skip_release=True)
 		
-	reporter.report()
+	reporter.report(plugin_list)
 	if reporter.failures > 0:
 		raise PullRequestCheckError(
 			"Check fails since there's failure during the fetch process. Check report messages above or workflow summary for more infomation.")

--- a/.github/workflows/scripts/pr_check.py
+++ b/.github/workflows/scripts/pr_check.py
@@ -7,7 +7,7 @@ import logging
 import os
 import sys
 
-sys.path.append('scripts')
+sys.path.append('scripts') # Make import and script runs from correct directory
 
 from common.constants import REPOS_ROOT
 from common.log import logger
@@ -15,52 +15,45 @@ from common.report import reporter
 from plugin.plugin_list import get_plugin_list
 
 
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.INFO) # https://github.com/MCDReforged/PluginCatalogue/pull/372
 
 
 class PullRequestCheckError(ValueError):
 	pass
 
 
-async def pr_check(target_ids):
-	plugin_list = get_plugin_list(target_ids)
-	reporter.record_command('pr_check')
-	reporter.record_script_start()
-	await plugin_list.fetch_data(fail_hard=False, skip_release=True)
-	reporter.report()
-	if reporter.failures > 0:
-		raise PullRequestCheckError(
-			"Check fails since there's failure during the fetch process. Check messages above or workflow summary for more infomation.")
-
-
-def main():
+def get_modified_plugins():
+	# https://github.com/marketplace/actions/changed-files
 	with open(os.path.join(REPOS_ROOT, '.github/outputs/all_changed_and_modified_files.json'), 'r', encoding='utf8') as f:
 		modified_files = json.load(f)
 
-	folders = []
+	plugins = set()
 
-	for f in modified_files:
-		folder_name = os.path.split(os.path.dirname(f))[-1]
-		if folder_name not in folders:
-			folders.append(folder_name)
+	for path in modified_files:
+		if path.startswith('plugins/'):
+			plugin_id = os.path.split(os.path.dirname(path))[-1] # plugin/<id>/... -> <id>
+			plugins.add(plugin_id)
+	
+	return plugins
 
-	if folders:
-		skip = False
-		msg = 'Modified plugin(s): \n'
-		for i in folders:
-			msg += f'- {i}\n'
+
+async def main():
+	target_ids = get_modified_plugins()
+
+	reporter.record_script_start()
+	reporter.record_command('pr_check')
+	
+	if not target_ids:
+		reporter.record_script_failure(ValueError("Empty plugin list"))
 	else:
-		msg = 'Skipped plugin checking as there are no checkable modifications.'
-		skip = True
-
-	print(msg)
-	if 'GITHUB_STEP_SUMMARY' in os.environ:
-		with open(os.environ['GITHUB_STEP_SUMMARY'], 'w') as f:
-			f.write(msg)
-
-	if not skip:
-		asyncio.run(pr_check(folders))
+		plugin_list = get_plugin_list(target_ids)
+		await plugin_list.fetch_data(fail_hard=False, skip_release=True)
+		
+	reporter.report()
+	if reporter.failures > 0:
+		raise PullRequestCheckError(
+			"Check fails since there's failure during the fetch process. Check report messages above or workflow summary for more infomation.")
 
 
 if __name__ == '__main__':
-	main()
+	asyncio.run(main())

--- a/.github/workflows/scripts/pr_check.py
+++ b/.github/workflows/scripts/pr_check.py
@@ -7,42 +7,60 @@ import logging
 import os
 import sys
 
-sys.path.append('scripts')
-
 from common.constants import REPOS_ROOT
 from common.log import logger
-from main import check
+from common.report import reporter
+from plugin.plugin_list import get_plugin_list
+
+sys.path.append('scripts')
+
 
 logger.setLevel(logging.INFO)
 
+
+class PullRequestCheckError(ValueError):
+    pass
+
+
+async def pr_check(target_ids):
+    plugin_list = get_plugin_list(target_ids)
+    reporter.record_command('pr_check')
+    reporter.record_script_start()
+    await plugin_list.fetch_data(fail_hard=False, skip_release=True)
+    reporter.report()
+    if reporter.failures > 0:
+        raise PullRequestCheckError(
+            "Check fails since there's failure during the fetch process. Check messages above or workflow summary for more infomation.")
+
+
 def main():
-	with open(os.path.join(REPOS_ROOT, '.github/outputs/all_changed_and_modified_files.json'), 'r', encoding='utf8') as f:
-		modified_files = json.load(f)
+    with open(os.path.join(REPOS_ROOT, '.github/outputs/all_changed_and_modified_files.json'), 'r', encoding='utf8') as f:
+        modified_files = json.load(f)
 
-	folders = []
+    folders = []
 
-	for f in modified_files:
-		folder_name = os.path.split(os.path.dirname(f))[-1]
-		if folder_name not in folders:
-			folders.append(folder_name)
+    for f in modified_files:
+        folder_name = os.path.split(os.path.dirname(f))[-1]
+        if folder_name not in folders:
+            folders.append(folder_name)
 
-	if folders:
-		skip = False
-		msg = 'Modified plugin(s): \n'
-		for i in folders:
-			msg += f'- {i}\n'
-	else:
-		msg = 'Skipped plugin checking as there are no checkable modifications.'
-		skip = True
+    if folders:
+        skip = False
+        msg = 'Modified plugin(s): \n'
+        for i in folders:
+            msg += f'- {i}\n'
+    else:
+        msg = 'Skipped plugin checking as there are no checkable modifications.'
+        skip = True
 
-	print(msg)
-	if 'GITHUB_STEP_SUMMARY' in os.environ:
-		with open(os.environ['GITHUB_STEP_SUMMARY'], 'w') as f:
-			f.write(msg)
+    print(msg)
+    if 'GITHUB_STEP_SUMMARY' in os.environ:
+        with open(os.environ['GITHUB_STEP_SUMMARY'], 'w') as f:
+            f.write(msg)
 
-	if not skip:
-		asyncio.run(check(folders))
+    if not skip:
+        asyncio.run(pr_check(folders))
 
 
 if __name__ == '__main__':
-	main()
+    main()

--- a/.github/workflows/scripts/pr_check.py
+++ b/.github/workflows/scripts/pr_check.py
@@ -19,48 +19,48 @@ logger.setLevel(logging.INFO)
 
 
 class PullRequestCheckError(ValueError):
-    pass
+	pass
 
 
 async def pr_check(target_ids):
-    plugin_list = get_plugin_list(target_ids)
-    reporter.record_command('pr_check')
-    reporter.record_script_start()
-    await plugin_list.fetch_data(fail_hard=False, skip_release=True)
-    reporter.report()
-    if reporter.failures > 0:
-        raise PullRequestCheckError(
-            "Check fails since there's failure during the fetch process. Check messages above or workflow summary for more infomation.")
+	plugin_list = get_plugin_list(target_ids)
+	reporter.record_command('pr_check')
+	reporter.record_script_start()
+	await plugin_list.fetch_data(fail_hard=False, skip_release=True)
+	reporter.report()
+	if reporter.failures > 0:
+		raise PullRequestCheckError(
+			"Check fails since there's failure during the fetch process. Check messages above or workflow summary for more infomation.")
 
 
 def main():
-    with open(os.path.join(REPOS_ROOT, '.github/outputs/all_changed_and_modified_files.json'), 'r', encoding='utf8') as f:
-        modified_files = json.load(f)
+	with open(os.path.join(REPOS_ROOT, '.github/outputs/all_changed_and_modified_files.json'), 'r', encoding='utf8') as f:
+		modified_files = json.load(f)
 
-    folders = []
+	folders = []
 
-    for f in modified_files:
-        folder_name = os.path.split(os.path.dirname(f))[-1]
-        if folder_name not in folders:
-            folders.append(folder_name)
+	for f in modified_files:
+		folder_name = os.path.split(os.path.dirname(f))[-1]
+		if folder_name not in folders:
+			folders.append(folder_name)
 
-    if folders:
-        skip = False
-        msg = 'Modified plugin(s): \n'
-        for i in folders:
-            msg += f'- {i}\n'
-    else:
-        msg = 'Skipped plugin checking as there are no checkable modifications.'
-        skip = True
+	if folders:
+		skip = False
+		msg = 'Modified plugin(s): \n'
+		for i in folders:
+			msg += f'- {i}\n'
+	else:
+		msg = 'Skipped plugin checking as there are no checkable modifications.'
+		skip = True
 
-    print(msg)
-    if 'GITHUB_STEP_SUMMARY' in os.environ:
-        with open(os.environ['GITHUB_STEP_SUMMARY'], 'w') as f:
-            f.write(msg)
+	print(msg)
+	if 'GITHUB_STEP_SUMMARY' in os.environ:
+		with open(os.environ['GITHUB_STEP_SUMMARY'], 'w') as f:
+			f.write(msg)
 
-    if not skip:
-        asyncio.run(pr_check(folders))
+	if not skip:
+		asyncio.run(pr_check(folders))
 
 
 if __name__ == '__main__':
-    main()
+	main()

--- a/scripts/common/report.py
+++ b/scripts/common/report.py
@@ -62,7 +62,7 @@ class Reporter:
 
 	@property
 	def failures(self) -> int:
-		"""Get failure amount."""
+		"""Get amount of plugin fetch failures."""
 		return sum(map(lambda msgs: len(msgs), self.__failures.values()))
 
 	def __dump(self, plugin_list: 'PluginList', f: IO[str]):

--- a/scripts/common/report.py
+++ b/scripts/common/report.py
@@ -58,6 +58,12 @@ class Reporter:
 		with self.__lock:
 			self.__rate_limit_remaining = remaining
 			self.__rate_limit_limit = limit
+	
+
+	@property
+	def failures(self) -> int:
+		"""Get failure amount."""
+		return sum(map(lambda msgs: len(msgs), self.__failures.values()))
 
 	def __dump(self, plugin_list: 'PluginList', f: IO[str]):
 		f.write('---------------------------------------\n\n')


### PR DESCRIPTION
注意到一些错误无法被PR check查出，因为它们并不在`fail_hard=True`时raise，但在[报告](https://github.com/MCDReforged/PluginCatalogue/actions/runs/10440360902/attempts/1#summary-28910175872)中仍视为failure，故作如下更改。同时，reporter信息可为PR检查提供更多有效参考。详情参见：

- 原有逻辑中introduction为漏网之鱼：
https://github.com/MCDReforged/PluginCatalogue/blob/645d356235204a5c61496369a78c9a3ae43ab6a8/.github/workflows/scripts/pr_check.py#L44
https://github.com/MCDReforged/PluginCatalogue/blob/645d356235204a5c61496369a78c9a3ae43ab6a8/scripts/main.py#L13-L15
https://github.com/MCDReforged/PluginCatalogue/blob/645d356235204a5c61496369a78c9a3ae43ab6a8/scripts/plugin/plugin.py#L211-L215

- 所有`fail_hard`抛出的failure都包含在reporter中，不会遗漏：
https://github.com/MCDReforged/PluginCatalogue/blob/645d356235204a5c61496369a78c9a3ae43ab6a8/scripts/plugin/plugin_list.py#L47-L59

未对`fail_hard`逻辑做修改的原因：`check()`的目的没有明确定义，让“漏网之鱼”被抛出不一定符合设想