### PR TITLE
feat?: do not raise on initialize fails

### DIFF
--- a/scripts/plugin/plugin_list.py
+++ b/scripts/plugin/plugin_list.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import shutil
 import time
+from traceback import format_exc
 from typing import Callable, List, Collection, Optional, Coroutine, Set
 
 from common import constants, log
@@ -28,15 +29,16 @@ class PluginList(List[Plugin]):
 					log.info('Found plugin {}'.format(folder))
 					try:
 						plugin = Plugin(folder)
+					except Exception as e:
+						log.exception('Failed to initialize plugin in folder "{}":\n {}'.format(folder, format_exc(e)))
+						reporter.record_plugin_failure(folder, 'Initialize plugin in folder {} failed'.format(folder), e)
+						continue
+					else:
 						if plugin.is_disabled():
 							log.info('Plugin {} is disabled due to "{}"'.format(plugin, plugin.get_disable_reason()))
 							reporter.record_plugin_disabled(plugin.id, plugin.get_disable_reason())
 						else:
 							self.append(plugin)
-					except Exception as e:
-						log.exception('Failed to initialize plugin in folder "{}"'.format(folder))
-						reporter.record_plugin_failure(folder, 'Initialize plugin in folder {} failed'.format(folder), e)
-						raise
 				else:
 					log.debug('Skipping plugin {}'.format(folder))
 


### PR DESCRIPTION
no reason for the entire script to raise for a plugin that fails to initialize. log and reporter has already recorded that, so just skip those plugins.