### PR TITLE
Add plugin: Ender Pearl TP

### DIFF
--- a/plugins/ender_pearl_tp/plugin_info.json
+++ b/plugins/ender_pearl_tp/plugin_info.json
@@ -1,0 +1,17 @@
+{
+    "id": "ender_pearl_tp",
+    "authors": [
+        {
+            "name": "Mooling0602",
+            "link": "https://github.com/Mooling0602"
+        }
+    ],
+    "repository": "https://github.com/Mooling0602/Ender-Pearl-TP-MCDR",
+    "branch": "main",
+    "related_path": ".",
+    "labels": ["tool"],
+    "introduction": {
+        "en_us": "README.md",
+        "zh_cn": "README_zh_cn.md"
+    }
+}


### PR DESCRIPTION
This plugin allows players to cost some ender pearls to teleport to anywhere they want.

<!-- 在上方撰写您想附加的信息 -->
<!-- Write your own things above -->
---

<!--
- 请确认您的 PR 符合《贡献指南》中的要求，然后勾选下方的复选框，不要修改其它内容
  勾选案例：- [x]
- Please confirm that your pull request meets the Contributing Guidelines, then tick the checkbox below,
  DO NOT MODIFY ANY OTHER CONTENT
  Ticked checkbox sample: - [x]
-->

<!--Checkmate-->
- [x] 我已阅读并检查，此 PR 符合 [贡献指南](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING_cn.md) 中的要求
  I have read and checked that my PR meets the requirements in the [Contributing Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)
