### PR TITLE
fix(labels): correct labels

### DIFF
--- a/plugins/advanced_calculator/plugin_info.json
+++ b/plugins/advanced_calculator/plugin_info.json
@@ -9,7 +9,9 @@
     "repository": "https://github.com/AnzhiZhang/MCDReforgedPlugins",
     "branch": "master",
     "related_path": "src/advanced_calculator",
-    "labels": ["tool"],
+    "labels": [
+        "information"
+    ],
     "introduction": {
         "en_us": "readme.md",
         "zh_cn": "readme.md"

--- a/plugins/auto_command/plugin_info.json
+++ b/plugins/auto_command/plugin_info.json
@@ -1,12 +1,14 @@
 {
-	"id": "auto_command",
-	"authors": [
-		{
-			"name": "bzyyyyyyyy",
-			"link": "https://github.com/bzyyyyyyyy"
-		}
-	],
-	"repository": "https://github.com/bzyyyyyyyy/MCDR-AutoCommand",
-	"branch": "master",
-	"labels": ["tool"]
+    "id": "auto_command",
+    "authors": [
+        {
+            "name": "bzyyyyyyyy",
+            "link": "https://github.com/bzyyyyyyyy"
+        }
+    ],
+    "repository": "https://github.com/bzyyyyyyyy/MCDR-AutoCommand",
+    "branch": "master",
+    "labels": [
+        "management"
+    ]
 }

--- a/plugins/auto_execute/plugin_info.json
+++ b/plugins/auto_execute/plugin_info.json
@@ -1,12 +1,15 @@
 {
-	"id": "auto_execute",
-	"authors": [
-		{
-			"name": "FRUITS-CANDY",
-			"link": "https://github.com/FRUITS-CANDY"
-		}
-	],
-	"repository": "https://github.com/Passion-Never-Dissipate/Auto-Execute",
-	"branch": "master",
-	"labels": ["tool"]
+    "id": "auto_execute",
+    "authors": [
+        {
+            "name": "FRUITS-CANDY",
+            "link": "https://github.com/FRUITS-CANDY"
+        }
+    ],
+    "repository": "https://github.com/Passion-Never-Dissipate/Auto-Execute",
+    "branch": "master",
+    "labels": [
+        "tool",
+        "management"
+    ]
 }

--- a/plugins/battery_saver/plugin_info.json
+++ b/plugins/battery_saver/plugin_info.json
@@ -9,7 +9,9 @@
     "repository": "https://github.com/Mooling0602/BatterySaver-MCDR",
     "branch": "main",
     "related_path": ".",
-    "labels": ["tool", "information"],
+    "labels": [
+        "management"
+    ],
     "introduction": {
         "en_us": "doc/introduction.md",
         "zh_cn": "doc/introduction-zh_cn.md"

--- a/plugins/carpet_bot_manager/plugin_info.json
+++ b/plugins/carpet_bot_manager/plugin_info.json
@@ -1,13 +1,16 @@
 {
     "id": "carpet_bot_manager",
     "authors": [
-        { 
-            "name": "YehowahLiu", 
-            "link": "https://github.com/YehowahLiu" 
+        {
+            "name": "YehowahLiu",
+            "link": "https://github.com/YehowahLiu"
         }
     ],
     "repository": "https://github.com/FAS-Server/CarpetBotManager",
     "branch": "main",
     "related_path": ".",
-    "labels": ["tool"]
+    "labels": [
+        "tool",
+        "management"
+    ]
 }

--- a/plugins/carpetbotlist/plugin_info.json
+++ b/plugins/carpetbotlist/plugin_info.json
@@ -1,8 +1,16 @@
 {
     "id": "carpetbotlist",
-    "authors": [{ "name": "ZeroKelvin", "link": "https://github.com/BelowZeroKelvin" }],
+    "authors": [
+        {
+            "name": "ZeroKelvin",
+            "link": "https://github.com/BelowZeroKelvin"
+        }
+    ],
     "repository": "https://github.com/BelowZeroKelvin/MCDR-CarpetBotList",
     "branch": "MCDR-2.x",
     "related_path": ".",
-    "labels": ["tool"]
+    "labels": [
+        "tool",
+        "management"
+    ]
 }

--- a/plugins/cato/plugin_info.json
+++ b/plugins/cato/plugin_info.json
@@ -1,8 +1,15 @@
 {
     "id": "cato",
-    "authors": [{ "name": "Harry-zklcdc", "link": "https://github.com/Harry-zklcdc" }],
+    "authors": [
+        {
+            "name": "Harry-zklcdc",
+            "link": "https://github.com/Harry-zklcdc"
+        }
+    ],
     "repository": "https://github.com/Harry-zklcdc/MCDR-Cato",
     "branch": "main",
     "related_path": ".",
-    "labels": ["tool"]
+    "labels": [
+        "management"
+    ]
 }

--- a/plugins/chatbridge/plugin_info.json
+++ b/plugins/chatbridge/plugin_info.json
@@ -1,12 +1,15 @@
 {
-	"id": "chatbridge",
-	"authors": [
-		{
-			"name": "Fallen_Breath",
-			"link": "https://github.com/Fallen-Breath"
-		}
-	],
-	"repository": "https://github.com/TISUnion/ChatBridge",
-	"branch": "master",
-	"labels": ["tool"]
+    "id": "chatbridge",
+    "authors": [
+        {
+            "name": "Fallen_Breath",
+            "link": "https://github.com/Fallen-Breath"
+        }
+    ],
+    "repository": "https://github.com/TISUnion/ChatBridge",
+    "branch": "master",
+    "labels": [
+        "tool",
+        "information"
+    ]
 }

--- a/plugins/chatbridgereforged_mc/plugin_info.json
+++ b/plugins/chatbridgereforged_mc/plugin_info.json
@@ -1,17 +1,20 @@
 {
-	"id": "chatbridgereforged_mc",
-	"authors": [
-		{
-			"name": "Ricky",
-			"link": "https://github.com/R1ckyH"
-		}
-	],
-	"repository": "https://github.com/R1ckyH/ChatBridgeReforged",
-	"branch": "master",
-	"related_path": "./ChatBridgeReforged_MC",
-	"labels": ["tool"],
-	"introduction": {
-		"en_us": "introduction.md",
-		"zh_cn": "introduction-zh_cn.md"
-	}
+    "id": "chatbridgereforged_mc",
+    "authors": [
+        {
+            "name": "Ricky",
+            "link": "https://github.com/R1ckyH"
+        }
+    ],
+    "repository": "https://github.com/R1ckyH/ChatBridgeReforged",
+    "branch": "master",
+    "related_path": "./ChatBridgeReforged_MC",
+    "labels": [
+        "tool",
+        "information"
+    ],
+    "introduction": {
+        "en_us": "introduction.md",
+        "zh_cn": "introduction-zh_cn.md"
+    }
 }

--- a/plugins/colored_chat/plugin_info.json
+++ b/plugins/colored_chat/plugin_info.json
@@ -9,7 +9,10 @@
     "repository": "https://github.com/AnzhiZhang/MCDReforgedPlugins",
     "branch": "master",
     "related_path": "src/.archived/ColoredChat",
-    "labels": ["tool"],
+    "labels": [
+        "tool",
+        "information"
+    ],
     "introduction": {
         "en_us": "readme.md",
         "zh_cn": "readme.md"

--- a/plugins/colorful_id/plugin_info.json
+++ b/plugins/colorful_id/plugin_info.json
@@ -1,16 +1,19 @@
 {
-  "id": "colorful_id",
-  "authors": [
-    {
-      "name": "Apricityx_",
-      "link": "https://github.com/Apricityx"
+    "id": "colorful_id",
+    "authors": [
+        {
+            "name": "Apricityx_",
+            "link": "https://github.com/Apricityx"
+        }
+    ],
+    "repository": "https://github.com/Apricityx/ColorfulID",
+    "branch": "master",
+    "labels": [
+        "tool",
+        "information"
+    ],
+    "introduction": {
+        "en_us": "introduction/introduction.md",
+        "zh_cn": "introduction/introduction-zh_cn.md"
     }
-  ],
-  "repository": "https://github.com/Apricityx/ColorfulID",
-  "branch": "master",
-  "labels": ["tool"],
-  "introduction": {
-    "en_us": "introduction/introduction.md",
-    "zh_cn": "introduction/introduction-zh_cn.md"
-  }
 }

--- a/plugins/command_aliases/plugin_info.json
+++ b/plugins/command_aliases/plugin_info.json
@@ -9,7 +9,9 @@
     "repository": "https://github.com/AnzhiZhang/MCDReforgedPlugins",
     "branch": "master",
     "related_path": "src/command_aliases",
-    "labels": ["tool"],
+    "labels": [
+        "management"
+    ],
     "introduction": {
         "en_us": "readme.md",
         "zh_cn": "readme_cn.md"

--- a/plugins/daytime/plugin_info.json
+++ b/plugins/daytime/plugin_info.json
@@ -1,8 +1,15 @@
 {
     "id": "daytime",
-    "authors": [{ "name": "ZeroKelvin", "link": "https://github.com/BelowZeroKelvin" }],
+    "authors": [
+        {
+            "name": "ZeroKelvin",
+            "link": "https://github.com/BelowZeroKelvin"
+        }
+    ],
     "repository": "https://github.com/BelowZeroKelvin/MCDR-Daytime",
     "branch": "MCDR-2.x",
     "related_path": ".",
-    "labels": ["tool"]
+    "labels": [
+        "information"
+    ]
 }

--- a/plugins/eulagree/plugin_info.json
+++ b/plugins/eulagree/plugin_info.json
@@ -1,10 +1,14 @@
 {
     "id": "eulagree",
-    "authors": [{
-        "name": "Huaji_MUR233",
-        "link": "https://github.com/HuajiMUR233"
-    }],
+    "authors": [
+        {
+            "name": "Huaji_MUR233",
+            "link": "https://github.com/HuajiMUR233"
+        }
+    ],
     "repository": "https://github.com/HuajiMURsMC/EULAgree",
     "branch": "main",
-    "labels": ["tool"]
+    "labels": [
+        "management"
+    ]
 }

--- a/plugins/homo_calculator/plugin_info.json
+++ b/plugins/homo_calculator/plugin_info.json
@@ -1,17 +1,17 @@
 {
-	"id": "homo_calculator",
-	"authors": [
-		{
-			"name": "meng877",
-			"link": "https://github.com/meng877"
-		}
-	],
-	"repository": "https://github.com/meng877/homo_calculator",
-	"branch": "master",
-	"labels": [
-		"tool"
-	],
-	"introduction": {
-		"en_us": "README.md"
-	}
+    "id": "homo_calculator",
+    "authors": [
+        {
+            "name": "meng877",
+            "link": "https://github.com/meng877"
+        }
+    ],
+    "repository": "https://github.com/meng877/homo_calculator",
+    "branch": "master",
+    "labels": [
+        "information"
+    ],
+    "introduction": {
+        "en_us": "README.md"
+    }
 }

--- a/plugins/jrrp/plugin_info.json
+++ b/plugins/jrrp/plugin_info.json
@@ -1,12 +1,14 @@
 {
-	"id": "jrrp",
-	"authors": [
-		{
-			"name": "Huaji_MUR233",
-			"link": "https://github.com/HuajiMUR233"
-		}
-	],
-	"repository": "https://github.com/HuajiMURsMC/jrrp",
-	"branch": "master",
-	"labels": ["tool"]
+    "id": "jrrp",
+    "authors": [
+        {
+            "name": "Huaji_MUR233",
+            "link": "https://github.com/HuajiMUR233"
+        }
+    ],
+    "repository": "https://github.com/HuajiMURsMC/jrrp",
+    "branch": "master",
+    "labels": [
+        "information"
+    ]
 }

--- a/plugins/jrrps/plugin_info.json
+++ b/plugins/jrrps/plugin_info.json
@@ -1,12 +1,14 @@
 {
-	"id": "jrrps",
-	"authors": [
-		{
-			"name": "SkyDynamic",
-			"link": "https://github.com/SkyDynamic"
-		}
-	],
-	"repository": "https://github.com/SkyDynamic/jrrps",
-	"branch": "master",
-	"labels": ["tool"]
+    "id": "jrrps",
+    "authors": [
+        {
+            "name": "SkyDynamic",
+            "link": "https://github.com/SkyDynamic"
+        }
+    ],
+    "repository": "https://github.com/SkyDynamic/jrrps",
+    "branch": "master",
+    "labels": [
+        "information"
+    ]
 }

--- a/plugins/matrix_sync/plugin_info.json
+++ b/plugins/matrix_sync/plugin_info.json
@@ -9,7 +9,9 @@
     "repository": "https://github.com/Mooling0602/MatrixSync-MCDR",
     "branch": "main",
     "related_path": ".",
-    "labels": ["tool", "information"],
+    "labels": [
+        "information"
+    ],
     "introduction": {
         "en_us": "doc/introduction.md",
         "zh_cn": "doc/introduction-zh_cn.md"

--- a/plugins/mcd_seen/plugin_info.json
+++ b/plugins/mcd_seen/plugin_info.json
@@ -1,20 +1,22 @@
 {
-	"id": "mcd_seen",
-	"authors": [
-		{
-			"name": "Pandaria",
-			"link": "https://github.com/Pandaria98"
-		},
-		{
-			"name": "Fallen_Breath",
-			"link": "https://github.com/Fallen-Breath"
-		},
-		{
-			"name": "Ra1ny_Yuki",
-			"link": "https://github.com/Ra1ny-Yuki"
-		}
-	],
-	"repository": "https://github.com/TISUnion/Seen",
-	"branch": "master",
-	"labels": ["tool"]
+    "id": "mcd_seen",
+    "authors": [
+        {
+            "name": "Pandaria",
+            "link": "https://github.com/Pandaria98"
+        },
+        {
+            "name": "Fallen_Breath",
+            "link": "https://github.com/Fallen-Breath"
+        },
+        {
+            "name": "Ra1ny_Yuki",
+            "link": "https://github.com/Ra1ny-Yuki"
+        }
+    ],
+    "repository": "https://github.com/TISUnion/Seen",
+    "branch": "master",
+    "labels": [
+        "information"
+    ]
 }

--- a/plugins/mcd_task/plugin_info.json
+++ b/plugins/mcd_task/plugin_info.json
@@ -1,20 +1,22 @@
 {
-	"id": "mcd_task",
-	"authors": [
-		{
-			"name": "Pandaria",
-			"link": "https://github.com/Pandaria98"
-		},
-		{
-			"name": "Fallen_Breath",
-			"link": "https://github.com/Fallen-Breath"
-		},
-		{
-			"name": "Ra1ny_Yuki",
-			"link": "https://github.com/Ra1ny-Yuki"
-		}
-	],
-	"repository": "https://github.com/TISUnion/Task",
-	"branch": "master",
-	"labels": ["tool"]
+    "id": "mcd_task",
+    "authors": [
+        {
+            "name": "Pandaria",
+            "link": "https://github.com/Pandaria98"
+        },
+        {
+            "name": "Fallen_Breath",
+            "link": "https://github.com/Fallen-Breath"
+        },
+        {
+            "name": "Ra1ny_Yuki",
+            "link": "https://github.com/Ra1ny-Yuki"
+        }
+    ],
+    "repository": "https://github.com/TISUnion/Task",
+    "branch": "master",
+    "labels": [
+        "information"
+    ]
 }

--- a/plugins/mcdr_pycraft_bot/plugin_info.json
+++ b/plugins/mcdr_pycraft_bot/plugin_info.json
@@ -1,12 +1,15 @@
 {
-	"id": "mcdr_pycraft_bot",
-	"authors": [
-		{
-			"name": "Fallen_Breath",
-			"link": "https://github.com/Fallen-Breath"
-		}
-	],
-	"repository": "https://github.com/TISUnion/MCDR-bot",
-	"branch": "master",
-	"labels": ["tool"]
+    "id": "mcdr_pycraft_bot",
+    "authors": [
+        {
+            "name": "Fallen_Breath",
+            "link": "https://github.com/Fallen-Breath"
+        }
+    ],
+    "repository": "https://github.com/TISUnion/MCDR-bot",
+    "branch": "master",
+    "labels": [
+        "tool",
+        "management"
+    ]
 }

--- a/plugins/multi_rcon_api/plugin_info.json
+++ b/plugins/multi_rcon_api/plugin_info.json
@@ -1,19 +1,19 @@
 {
-	"id": "multi_rcon_api",
-	"authors": [
-		{
-			"name": "YehowahLiu",
-			"link": "https://github.com/YehowahLiu"
-		}
-	],
-	"repository": "https://github.com/FAS-Server/MultiRconAPI",
-	"branch": "main",
-	"related_path": ".",
-	"labels": [
-		"tool",
-		"api"
-	],
-	"introduction": {
-		"en_us": "README.md"
-	}
+    "id": "multi_rcon_api",
+    "authors": [
+        {
+            "name": "YehowahLiu",
+            "link": "https://github.com/YehowahLiu"
+        }
+    ],
+    "repository": "https://github.com/FAS-Server/MultiRconAPI",
+    "branch": "main",
+    "related_path": ".",
+    "labels": [
+        "management",
+        "api"
+    ],
+    "introduction": {
+        "en_us": "README.md"
+    }
 }

--- a/plugins/quick_run_cmd/plugin_info.json
+++ b/plugins/quick_run_cmd/plugin_info.json
@@ -1,16 +1,18 @@
 {
-	"id": "quick_run_cmd",
-	"authors": [
-		{
-			"name": "Ricky",
-			"link": "https://github.com/R1ckyH"
-		}
-	],
-	"repository": "https://github.com/R1ckyH/quick_run_cmd",
-	"branch": "master",
-	"labels": ["tool"],
-	"introduction": {
-		"en_us": "introduction.md",
-		"zh_cn": "introduction-zh_cn.md"
-	}
+    "id": "quick_run_cmd",
+    "authors": [
+        {
+            "name": "Ricky",
+            "link": "https://github.com/R1ckyH"
+        }
+    ],
+    "repository": "https://github.com/R1ckyH/quick_run_cmd",
+    "branch": "master",
+    "labels": [
+        "management"
+    ],
+    "introduction": {
+        "en_us": "introduction.md",
+        "zh_cn": "introduction-zh_cn.md"
+    }
 }

--- a/plugins/run_some_commands/plugin_info.json
+++ b/plugins/run_some_commands/plugin_info.json
@@ -1,7 +1,15 @@
 {
     "id": "run_some_commands",
-    "authors": [{ "name": "FlyingShuriken", "link": "https://github.com/FlyingShuriken" }],
+    "authors": [
+        {
+            "name": "FlyingShuriken",
+            "link": "https://github.com/FlyingShuriken"
+        }
+    ],
     "repository": "https://github.com/FlyingShuriken/MCDR-plugins",
     "branch": "main",
-    "labels": ["tool"]
+    "labels": [
+        "tool",
+        "management"
+    ]
 }

--- a/plugins/showshowway/plugin_info.json
+++ b/plugins/showshowway/plugin_info.json
@@ -1,17 +1,18 @@
 {
-	"id": "showshowway",
-	"authors": [
-		{
-			"name": "WhiteXero",
-			"link": "https://github.com/WhiteXero"
-		}
-	],
-	"repository": "https://github.com/WhiteXero/ShowIt",
-	"branch": "main",
-	"labels": [
-		"tool"
-	],
-	"introduction": {
-		"en_us": "README.md"
-	}
+    "id": "showshowway",
+    "authors": [
+        {
+            "name": "WhiteXero",
+            "link": "https://github.com/WhiteXero"
+        }
+    ],
+    "repository": "https://github.com/WhiteXero/ShowIt",
+    "branch": "main",
+    "labels": [
+        "tool",
+        "information"
+    ],
+    "introduction": {
+        "en_us": "README.md"
+    }
 }

--- a/plugins/simple_op/plugin_info.json
+++ b/plugins/simple_op/plugin_info.json
@@ -1,17 +1,17 @@
 {
-	"id": "simple_op",
-	"authors": [
-		{
-			"name": "Fallen_Breath",
-			"link": "https://github.com/Fallen-Breath"
-		}
-	],
-	"repository": "https://github.com/TISUnion/SimpleOP",
-	"branch": "master",
-	"labels": [
-		"tool"
-	],
-	"introduction": {
-		"en_us": "readme.md"
-	}
+    "id": "simple_op",
+    "authors": [
+        {
+            "name": "Fallen_Breath",
+            "link": "https://github.com/Fallen-Breath"
+        }
+    ],
+    "repository": "https://github.com/TISUnion/SimpleOP",
+    "branch": "master",
+    "labels": [
+        "management"
+    ],
+    "introduction": {
+        "en_us": "readme.md"
+    }
 }

--- a/plugins/simple_translator/plugin_info.json
+++ b/plugins/simple_translator/plugin_info.json
@@ -1,17 +1,17 @@
 {
-	"id": "simple_translator",
-	"authors": [
-		{
-			"name": "skuzow",
-			"link": "https://github.com/skuzow"
-		}
-	],
-	"repository": "https://github.com/skuzow/simple-translator",
-	"branch": "master",
-	"labels": [
-		"tool"
-	],
-	"introduction": {
-		"en_us": "README.md"
-	}
+    "id": "simple_translator",
+    "authors": [
+        {
+            "name": "skuzow",
+            "link": "https://github.com/skuzow"
+        }
+    ],
+    "repository": "https://github.com/skuzow/simple-translator",
+    "branch": "master",
+    "labels": [
+        "information"
+    ],
+    "introduction": {
+        "en_us": "README.md"
+    }
 }

--- a/plugins/stats_helper/plugin_info.json
+++ b/plugins/stats_helper/plugin_info.json
@@ -1,12 +1,14 @@
 {
-	"id": "stats_helper",
-	"authors": [
-		{
-			"name": "Fallen_Breath",
-			"link": "https://github.com/Fallen-Breath"
-		}
-	],
-	"repository": "https://github.com/TISUnion/StatsHelper",
-	"branch": "master",
-	"labels": ["tool", "information"]
+    "id": "stats_helper",
+    "authors": [
+        {
+            "name": "Fallen_Breath",
+            "link": "https://github.com/Fallen-Breath"
+        }
+    ],
+    "repository": "https://github.com/TISUnion/StatsHelper",
+    "branch": "master",
+    "labels": [
+        "information"
+    ]
 }

--- a/plugins/todolist/plugin_info.json
+++ b/plugins/todolist/plugin_info.json
@@ -9,7 +9,9 @@
     "repository": "https://github.com/Flash-Z/MCDReforgedPlugins",
     "branch": "master",
     "related_path": "ToDoList",
-    "labels": ["tool", "information"],
+    "labels": [
+        "information"
+    ],
     "introduction": {
         "en_us": "README.md",
         "zh_cn": "README.md"

--- a/plugins/ye_announcement/plugin_info.json
+++ b/plugins/ye_announcement/plugin_info.json
@@ -1,17 +1,17 @@
 {
-	"id": "ye_announcement",
-	"authors": [
-		{
-			"name": "XiaoYeYa",
-			"link": "https://github.com/XiaoYeYa"
-		}
-	],
-	"repository": "https://github.com/XiaoYeYa/ye_announcement/",
-	"branch": "master",
-	"labels": [
-		"tool"
-	],
-	"introduction": {
-		"en_us": "README.md"
-	}
+    "id": "ye_announcement",
+    "authors": [
+        {
+            "name": "XiaoYeYa",
+            "link": "https://github.com/XiaoYeYa"
+        }
+    ],
+    "repository": "https://github.com/XiaoYeYa/ye_announcement/",
+    "branch": "master",
+    "labels": [
+        "information"
+    ],
+    "introduction": {
+        "en_us": "README.md"
+    }
 }


### PR DESCRIPTION
## Correct plugin labels

Currently, there is a significant number of incorrectly labeled plugins in catalogue. The misuse of the TOOLS tag is particularly severe. Therefore, re-label those plugins.

## Principles
- All plugins related to ‘displaying information’ are labelled as infomation. e.g. jrrp, calculator, task_list
- All plugins for out-of-game and command management or execution are labelled as management. e.g. bot manager, command aliases

## Complaint

Plugin labeling is very inaccurate because the TOOLS tag is too vaguely defined - I think all plugins in this catalogue can be called ‘useful tools’.

## Plugin list

| Plugin | Description | Labels | New Labels |
| - | - | - | - |
| advanced_calculator | Provides multiple convenient in-game calculations | tool | information |
| auto_command | A plugin that send send commands automaticly | tool | management |
| auto_execute | An MCDR plugin that stores various instructions for multimodal execution based on scripts | tool | tool, management |
| battery_saver | Check battery of host machine and automatically stop server when it's low. | tool, information | management |
| carpet_bot_manager | A carpet bot manage plugin, able to spawn bot and make it execute actions | tool | tool, management |
| carpetbotlist | Help you manage your carpet fake player | tool | tool, management |
| cato | Plugin Cato | tool | management |
| chatbridge | Broadcast chats between Minecraft servers and more | tool | tool, information |
| chatbridgereforged_mc | Reforged of ChatBridge, interaction with other clients(such as minecraft server, discord bots or other custom clients). | tool | tool, information |
| colored_chat | Support formatting codes for vanilla | tool | tool, information |
| colorful_id | Colorful player names! | tool | tool, information |
| command_aliases | Aliases commands | tool | management |
| daytime | show time in minecraft | tool | information |
| eulagree | I always agree with EULA, don't ask me | tool | management |
| homo_calculator | !!homo <int> 将任何数字转化为114514四则运算的形式 | tool | information |
| jrrp | 《今日人品》 | tool | information |
| jrrps | Test today's luck | tool | information |
| matrix_sync | Sync messages between online game and Matrix groups. | tool, information | information |
| mcd_seen | Show laziness rank easily | tool | information |
| mcd_task | A plugin to show tasks of project in progress | tool | information |
| mcdr_pycraft_bot | MCDR Bot powered by pyCraft | tool | tool, management |
| multi_rcon_api | An api to make it easier to control group server by rcon. | tool, api | management, api |
| quick_run_cmd | A plugin for run command quickly. | tool | management |
| run_some_commands | Let player run whitelisted vanilla command | tool | tool, management |
| showshowway | 获取玩家的头，或者展示手上的物品 | tool | tool, information |
| simple_op | !!op to get op, !!restart to restart the server | tool | management |
| simple_translator | In-game translator | tool | information |
| stats_helper | A Minecraft statistic helper | tool, information | information |
| todolist | ToDoList | tool, information | information |
| ye_announcement | Announce players when they join the game | tool | information |
