### PR TITLE
Add plugin MSync.PlayerTips

### DIFF
--- a/plugins/msync_player_tips/plugin_info.json
+++ b/plugins/msync_player_tips/plugin_info.json
@@ -1,0 +1,17 @@
+{
+    "id": "msync_player_tips",
+    "authors": [
+        {
+            "name": "Mooling0602",
+            "link": "https://github.com/Mooling0602"
+        }
+    ],
+    "repository": "https://github.com/Mooling0602/MSyncSubpacks",
+    "branch": "main",
+    "related_path": "src/PlayerTips",
+    "labels": ["information"],
+    "introduction": {
+        "en_us": "README.md",
+        "zh_cn": "README.md"
+    }
+}

--- a/plugins/msync_player_tips/plugin_info.json
+++ b/plugins/msync_player_tips/plugin_info.json
@@ -7,7 +7,7 @@
         }
     ],
     "repository": "https://github.com/Mooling0602/MSyncSubpacks",
-    "branch": "main",
+    "branch": "rel",
     "related_path": "src/PlayerTips",
     "labels": ["information"],
     "introduction": {


### PR DESCRIPTION
此插件为MatrixSync的子包，安装后可以使主插件转发玩家上线和下线的消息到Matrix房间内
<!-- 在上方撰写您想附加的信息 -->
<!-- Write your own things above -->
---

<!--
- 请确认您的 PR 符合《贡献指南》中的要求，然后勾选下方的复选框，不要修改其它内容
  勾选案例：- [x]
- Please confirm that your pull request meets the Contributing Guidelines, then tick the checkbox below,
  DO NOT MODIFY ANY OTHER CONTENT
  Ticked checkbox sample: - [x]
-->

<!--Checkmate-->
- [x] 我已阅读并检查，此 PR 符合 [贡献指南](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING_cn.md) 中的要求
  I have read and checked that my PR meets the requirements in the [Contributing Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)
