### PR TITLE
feat: add plugin InitServer with id "init_server"

### DIFF
--- a/plugins/init_server/plugin_info.json
+++ b/plugins/init_server/plugin_info.json
@@ -9,7 +9,7 @@
     "repository": "https://github.com/Mooling0602/InitServer-MCDR",
     "branch": "main",
     "related_path": ".",
-    "labels": ["tool"],
+    "labels": ["management"],
     "introduction": {
         "en_us": "doc/description_en_us.md",
         "zh_cn": "doc/description_zh_cn.md"

--- a/plugins/init_server/plugin_info.json
+++ b/plugins/init_server/plugin_info.json
@@ -1,0 +1,17 @@
+{
+    "id": "init_server",
+    "authors": [
+        {
+            "name": "Mooling0602",
+            "link": "https://github.com/Mooling0602"
+        }
+    ],
+    "repository": "https://github.com/Mooling0602/InitServer-MCDR",
+    "branch": "main",
+    "related_path": ".",
+    "labels": ["tool"],
+    "introduction": {
+        "en_us": "doc/description_en_us.md",
+        "zh_cn": "doc/description_zh_cn.md"
+    }
+}


### PR DESCRIPTION
一个自动化工具用于在首次启动（不是首次也行）服务器时快速进行一些配置，方便服主专注于其他工作
目前功能不多，可暂且视为外加了Rcon配置功能的增强版[EULAgree](https://mcdreforged.com/zh-CN/plugin/eulagree)
<!-- 在上方撰写您想附加的信息 -->
<!-- Write your own things above -->
---

<!--
- 请确认您的 PR 符合《贡献指南》中的要求，然后勾选下方的复选框，不要修改其它内容
  勾选案例：- [x]
- Please confirm that your pull request meets the Contributing Guidelines, then tick the checkbox below,
  DO NOT MODIFY ANY OTHER CONTENT
  Ticked checkbox sample: - [x]
-->

<!--Checkmate-->
- [x] 我已阅读并检查，此 PR 符合 [贡献指南](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING_zh_cn.md) 中的要求
  I have read and checked that my PR meets the requirements in the [Contributing Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)
