### PR TITLE
feat: add welcome message for new contributers

### DIFF
--- a/.github/workflows/scripts/check.py
+++ b/.github/workflows/scripts/check.py
@@ -108,11 +108,11 @@ MSG_CHECKLIST = '''
 logger.setLevel(logging.INFO)
 
 # ---- On closed ---- #
-if EVENT_TYPE == EventType.CLOSED:
+if EVENT_TYPE == EventType.CLOSED and IS_MERGED == 'true':  # merged
     author, is_first_time = gh.check_contributor()
-    if is_first_time and IS_MERGED == 'true':  # merged
+    if is_first_time:
         gh.pr_comment(MSG_MERGED)
-    sys.exit(0)
+        sys.exit(0)
 
 # ---- No limit on recheck ---- #
 if EVENT_TYPE == EventType.LABELED:

--- a/.github/workflows/scripts/check.py
+++ b/.github/workflows/scripts/check.py
@@ -71,6 +71,21 @@ We appreciate your hard work and valuable input. If you have any further questio
 Happy coding!
 '''.strip()
 
+FIRST_TIME_HEADER = '''
+**Hi, {}!**  
+This is your first contribution to the catalogue. Welcome! 🎉  
+
+To ensure a smooth review process, please:  
+- 📖 **Read the [Contribution Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)** (if you haven’t already).  
+- 🔍 **Check existing plugins** for reference on formatting and metadata.
+
+If you’ve added/modified plugins, a report will be generated below.
+- ✅ **Verify your changes** by reading the report.
+
+We’ll review your PR soon — thanks for your patience!
+Hope you have a great day!
+'''.strip()
+
 MSG_HEADER = '''
 Thanks for your contribution! 🎉
 Please be patient before we done checking. If you've added or modified plugins, a brief report will be generated below.
@@ -94,7 +109,8 @@ logger.setLevel(logging.INFO)
 
 # ---- On closed ---- #
 if EVENT_TYPE == EventType.CLOSED:
-    if IS_MERGED == 'true':  # merged
+    author, is_first_time = gh.check_contributor()
+    if is_first_time and IS_MERGED == 'true':  # merged
         gh.pr_comment(MSG_MERGED)
     sys.exit(0)
 
@@ -152,11 +168,6 @@ logger.info(f'Identified labels: {", ".join(map(str, actions.labels))}')
 
 # ---- Run plugin checks and generate report ---- #
 
-reply: str = MSG_HEADER
-
-if Tag.PLG_ADD in actions.tags:
-    reply += MSG_CHECKLIST
-
 report: Optional[str] = None
 
 if actions.plugins:
@@ -183,6 +194,14 @@ else:
 # ---- Label and comment ---- #
 
 if EVENT_TYPE == EventType.OPENED:
+    author, is_first_time = gh.check_contributor()
+
+    reply = FIRST_TIME_HEADER.format(f'@{author}' if author else 'contributor') \
+        if is_first_time else MSG_HEADER
+
+    if Tag.PLG_ADD in actions.tags:
+        reply += MSG_CHECKLIST
+
     gh.pr_label(add_labels=sorted(actions.labels))
     gh.pr_comment(reply)
 

--- a/.github/workflows/scripts/check.py
+++ b/.github/workflows/scripts/check.py
@@ -62,13 +62,17 @@ EVENT_TYPE = EventType(os.environ.get('EVENT_TYPE'))
 IS_MERGED = os.environ.get('IS_MERGED', 'false')
 
 MSG_MERGED = '''
-Well done! 🎉
+{},
 
-Your pull request has been successfully merged.
+Congratulations on your first merged contribution! 🎉✨
+Thank you for joining the community — your PR is now a part of the Plugin Catalogue!
 
-We appreciate your hard work and valuable input. If you have any further questions or need additional changes, feel free to reach out.
+A few friendly reminders:
+🕒 Your changes may take a short time to appear in the catalogue.
+✅ Check back later to make sure everything displays as expected.
 
-Happy coding!
+We’re thrilled to welcome you as a contributor and hope to see more from you in the future!
+Welcome aboard, and happy coding! 🚀
 '''.strip()
 
 FIRST_TIME_HEADER = '''
@@ -111,7 +115,7 @@ logger.setLevel(logging.INFO)
 if EVENT_TYPE == EventType.CLOSED and IS_MERGED == 'true':  # merged
     author, is_first_time = gh.check_contributor()
     if is_first_time:
-        gh.pr_comment(MSG_MERGED)
+        gh.pr_comment(MSG_MERGED.format(f'@{author}' if author else 'Contributor'))
         sys.exit(0)
 
 # ---- No limit on recheck ---- #
@@ -196,7 +200,7 @@ else:
 if EVENT_TYPE == EventType.OPENED:
     author, is_first_time = gh.check_contributor()
 
-    reply = FIRST_TIME_HEADER.format(f'@{author}' if author else 'contributor') \
+    reply = FIRST_TIME_HEADER.format(f'@{author}' if author else 'Contributor') \
         if is_first_time else MSG_HEADER
 
     if Tag.PLG_ADD in actions.tags:

--- a/.github/workflows/scripts/gh_cli.py
+++ b/.github/workflows/scripts/gh_cli.py
@@ -124,7 +124,7 @@ def check_contributor(pr_number: str = PR_NUMBER) -> Tuple[Optional[str], bool]:
         pr_number (str): The pull request number.
 
     Returns:
-        Tuple[str, bool]: A tuple containing the author's login and a boolean indicating if they are a first-time contributor.
+        Tuple[Optional[str], bool]: A tuple containing the author's login and a boolean indicating if they are a first-time contributor.
     """
     logger.info(f'Checking contributor for PR: #{pr_number}')
 

--- a/.github/workflows/scripts/gh_cli.py
+++ b/.github/workflows/scripts/gh_cli.py
@@ -30,7 +30,7 @@ in the `scripts` folder of the project root. If not, see
 
 import os
 import subprocess
-from typing import Optional
+from typing import Optional, Tuple
 
 from common.log import logger
 from utilities import COMMENT_SIGN
@@ -114,3 +114,46 @@ def pr_label(add_labels: Optional[list[str]] = None, remove_labels: Optional[lis
         logger.info(result.decode('utf-8'))
     except Exception as e:
         logger.error(f'Failed to label: {e}')
+
+
+def check_contributor(pr_number: str = PR_NUMBER) -> Tuple[str, bool]:
+    """Check if the author of a PR is a first-time contributor.
+
+    Args:
+        pr_number (str): The pull request number.
+
+    Returns:
+        Tuple[str, bool]: A tuple containing the author's login and a boolean indicating if they are a first-time contributor.
+    """
+    logger.info(f'Checking contributor for PR: #{pr_number}')
+
+    query = ' '.join(map(str.strip, f"""
+    {{
+      repository(owner: "MCDReforged", name: "PluginCatalogue") {{
+        pullRequest(number: {pr_number}) {{
+          author {{
+            login
+          }}
+          authorAssociation
+        }}
+      }}
+    }}
+    """.split('\n')))
+
+    cmd = [
+        'gh', 'api', 'graphql', '--jq',
+        r'.data.repository.pullRequest | "\(.author.login) \(.authorAssociation == "FIRST_TIME_CONTRIBUTOR")"',
+        '-F', f'query={query}']
+
+    try:
+        result = subprocess.check_output(cmd)   # Alex326 false
+        result = result.decode('utf-8').strip().split(' ')
+        author_login = result[0]
+        is_first_time = result[1].lower() == 'true'
+
+        logger.info(f'Contributor: {author_login}, First Time: {is_first_time}')
+        return author_login, is_first_time
+
+    except Exception as e:
+        logger.error(f'Failed to fetch contributor data: {e}')
+        return None, False

--- a/.github/workflows/scripts/gh_cli.py
+++ b/.github/workflows/scripts/gh_cli.py
@@ -37,6 +37,7 @@ from utilities import COMMENT_SIGN
 
 EXECUTABLE = 'gh'
 PR_NUMBER = os.environ.get('PR_NUMBER')
+CATALOGUE_REPO = 'MCDReforged/PluginCatalogue'.split('/')
 
 if 'GH_TOKEN' not in os.environ:
     os.environ['GH_TOKEN'] = os.environ.get('github_api_token', '')
@@ -129,7 +130,7 @@ def check_contributor(pr_number: str = PR_NUMBER) -> Tuple[Optional[str], bool]:
 
     query = ' '.join(map(str.strip, f"""
     {{
-      repository(owner: "MCDReforged", name: "PluginCatalogue") {{
+      repository(owner: "{REPO[0]}", name: "{REPO[1]}") {{
         pullRequest(number: {pr_number}) {{
           author {{
             login

--- a/.github/workflows/scripts/gh_cli.py
+++ b/.github/workflows/scripts/gh_cli.py
@@ -116,7 +116,7 @@ def pr_label(add_labels: Optional[list[str]] = None, remove_labels: Optional[lis
         logger.error(f'Failed to label: {e}')
 
 
-def check_contributor(pr_number: str = PR_NUMBER) -> Tuple[str, bool]:
+def check_contributor(pr_number: str = PR_NUMBER) -> Tuple[Optional[str], bool]:
     """Check if the author of a PR is a first-time contributor.
 
     Args:

--- a/.github/workflows/scripts/gh_cli.py
+++ b/.github/workflows/scripts/gh_cli.py
@@ -130,7 +130,7 @@ def check_contributor(pr_number: str = PR_NUMBER) -> Tuple[Optional[str], bool]:
 
     query = ' '.join(map(str.strip, f"""
     {{
-      repository(owner: "{REPO[0]}", name: "{REPO[1]}") {{
+      repository(owner: "{CATALOGUE_REPO[0]}", name: "{CATALOGUE_REPO[1]}") {{
         pullRequest(number: {pr_number}) {{
           author {{
             login


### PR DESCRIPTION
Introduces a welcome message for first-time contributors, and optimizes merged message visibility.

- Displays a friendly header with onboarding tips when a new contributor opens a PR.
- Now only sends the merged confirmation message to first-time contributors.
  (sending a message on every merge is almost a spam

This change introduces 1 additional GraphQL API request on PR opened or merged.
Which means, 2 requests when PR merged, or 1 request when PR closed.