### PR TITLE
feat: add plugin spawn_fixer

### DIFF
--- a/plugins/spawn_fixer/plugin_info.json
+++ b/plugins/spawn_fixer/plugin_info.json
@@ -1,0 +1,17 @@
+{
+    "id": "spawn_fixer",
+    "authors": [
+        {
+            "name": "Mooling0602",
+            "link": "https://github.com/Mooling0602"
+        }
+    ],
+    "repository": "https://github.com/Mooling0602/SpawnFixer-MCDR",
+    "branch": "main",
+    "related_path": ".",
+    "labels": ["tool"],
+    "introduction": {
+        "en_us": "descriptions/en_us.md",
+        "zh_cn": "descriptions/zh_cn.md"
+    }
+}


### PR DESCRIPTION
原版游戏会将玩家复活在出生点y轴最高的方块上，该插件对此进行了修正，使玩家能够被正确重生在指定的坐标上，无论头顶是否有方块遮挡。
<!-- 在上方撰写您想附加的信息 -->
<!-- Write your own things above -->
---

<!--
- 请确认您的 PR 符合《贡献指南》中的要求，然后勾选下方的复选框，不要修改其它内容
  勾选案例：- [x]
- Please confirm that your pull request meets the Contributing Guidelines, then tick the checkbox below,
  DO NOT MODIFY ANY OTHER CONTENT
  Ticked checkbox sample: - [x]
-->

<!--Checkmate-->
- [x] 我已阅读并检查，此 PR 符合 [贡献指南](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING_zh_cn.md) 中的要求
  I have read and checked that my PR meets the requirements in the [Contributing Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)
