### PR TITLE
Create plugin_info.json

### DIFF
--- a/plugins/tick_and_update/plugin_info.json
+++ b/plugins/tick_and_update/plugin_info.json
@@ -1,0 +1,17 @@
+{
+    "id": "tick_and_update",
+    "authors": [
+        {
+            "name": "czw06",
+            "link": "https://github.com/czw63/"
+        }
+    ],
+    "repository": "https://github.com/czw63/tick_and_update",
+    "branch": "main",
+    "related_path": ".",
+    "labels": ["tool"],
+    "introduction": {
+        "en_us": "README.md",
+        "zh_cn": "README.md"
+    }
+}


### PR DESCRIPTION
新增插件tick_and_update

单纯给懒人生电服开关交互更新抑制用的
再加上我服务器不知道为什么1.21.6的carpet无法下放tick权限
顺手找deepseek写了这个插件（）

<!-- 在上方撰写您想附加的信息 -->
<!-- Write your own things above -->
---

<!--
- 请确认您的 PR 符合《贡献指南》中的要求，然后勾选下方的复选框，不要修改其它内容
  勾选案例：- [x]
- Please confirm that your pull request meets the Contributing Guidelines, then tick the checkbox below,
  DO NOT MODIFY ANY OTHER CONTENT
  Ticked checkbox sample: - [x]
-->

<!--Checkmate-->
- [x] 我已阅读并检查，此 PR 符合 [贡献指南](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING_zh_cn.md) 中的要求
  I have read and checked that my PR meets the requirements in the [Contributing Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)
