### PR TITLE
chore: add concurrency settings to CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Catalogue CI
 
+concurrency:
+  group: update
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/scheduled_update.yml
+++ b/.github/workflows/scheduled_update.yml
@@ -1,5 +1,8 @@
 name: Scheduled update
 
+concurrency:
+  group: update
+
 on:
   schedule:
     # Runs at minute 15 and 45 of every hour


### PR DESCRIPTION
## What happened

A [`ci`](https://github.com/MCDReforged/PluginCatalogue/actions/runs/16703133971/job/47277301138) failed because a [`scheduled update`](https://github.com/MCDReforged/PluginCatalogue/actions/runs/16703135442) was pushed before the CI.

## What to do

Add concurrency settings to the workflow.
See: https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency

A CI should have higher priority than scheduled updates, as it runs with `check: true`.

## Why not in `_update.yml`

If I understand correctly, adding a concurrency setting in `_update.yml` may cause a scheduled update to override a CI run.