### PR TITLE
feat: add plugin PiPInstaller

### DIFF
--- a/plugins/pip_installer/plugin_info.json
+++ b/plugins/pip_installer/plugin_info.json
@@ -9,7 +9,7 @@
     "repository": "https://github.com/Mooling0602/PiPInstaller-MCDR",
     "branch": "main",
     "related_path": ".",
-    "labels": ["tool"],
+    "labels": ["management"],
     "introduction": {
         "en_us": "README.md",
         "zh_cn": "README.md"


### PR DESCRIPTION
这是一个工具类插件，用于在MCDReforged控制台中快速安装Python包，无需另外启动Shell环境。
<!-- 在上方撰写您想附加的信息 -->
<!-- Write your own things above -->
---

<!--
- 请确认您的 PR 符合《贡献指南》中的要求，然后勾选下方的复选框，不要修改其它内容
  勾选案例：- [x]
- Please confirm that your pull request meets the Contributing Guidelines, then tick the checkbox below,
  DO NOT MODIFY ANY OTHER CONTENT
  Ticked checkbox sample: - [x]
-->

<!--Checkmate-->
- [x] 我已阅读并检查，此 PR 符合 [贡献指南](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING_zh_cn.md) 中的要求
  I have read and checked that my PR meets the requirements in the [Contributing Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)
