### PR TITLE
Create plugin_info.json

### DIFF
--- a/plugins/tools/plugin_info.json
+++ b/plugins/tools/plugin_info.json
@@ -1,0 +1,16 @@
+{
+  "id": "tools",
+  "authors": [
+    {
+      "name": "MoonShadow233",
+      "link": "https://github.com/MoonShadow233"
+    }
+  ],
+  "repository": "https://github.com/MoonShadow233/MCDR_Plugin-Tools",
+  "branch": "master",
+  "related_path": ".",
+  "labels": ["tool", "management"],
+  "introduction": {
+    "zh_cn": "README.md"
+  }
+}


### PR DESCRIPTION
此次提交添加了 **ToolsPlugin** 插件的 `plugin_info.json` 文件，以便将其列入官方插件目录。

**插件简介**
ToolsPlugin 是一个为 MCDReforged 服务器设计的实用生存工具插件，提供了一系列方便服务器管理和玩家游玩的工具。

**相关信息**
- 插件仓库地址：https://github.com/MoonShadow233/ToolsPlugin
- 插件ID: `tools` (已在 json 文件中定义)
- 该 PR 仅添加目录信息文件，不影响任何现有插件。

---

<!--
- 请确认您的 PR 符合《贡献指南》中的要求，然后勾选下方的复选框，不要修改其它内容
  勾选案例：- [x]
- Please confirm that your PR meets the Contributing Guidelines, then tick the checkbox below,
  DO NOT MODIFY ANY OTHER CONTENT
  Ticked checkbox example: - [x]
-->

<!--Checkmate-->
- [x] 我已阅读并检查，此 PR 符合 [贡献指南](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING_zh_cn.md) 中的要求
  I have read and checked that my PR meets the requirements in the [Contributing Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)