### PR TITLE
Rename plugin ID from 'colorful_id' to 'color_me'

### DIFF
--- a/plugins/colorful_id/plugin_info.json
+++ b/plugins/colorful_id/plugin_info.json
@@ -1,5 +1,5 @@
 {
-  "id": "colorful_id",
+  "id": "color_me",
   "authors": [
     {
       "name": "Apricityx_",


### PR DESCRIPTION

修复了插件 id 不匹配的问题
---

- [x] 我已阅读并检查，此 PR 符合 [贡献指南](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING_zh_cn.md) 中的要求
  I have read and checked that my PR meets the requirements in the [Contributing Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)
