### PR TITLE
fix: rename plugin colorful_id to color_me

### DIFF
--- a/plugins/color_me/plugin_info.json
+++ b/plugins/color_me/plugin_info.json
@@ -1,12 +1,12 @@
 {
-  "id": "colorful_id",
+  "id": "color_me",
   "authors": [
     {
       "name": "Apricityx_",
       "link": "https://github.com/Apricityx"
     }
   ],
-  "repository": "https://github.com/Apricityx/ColorfulID",
+  "repository": "https://github.com/Apricityx/ColorMe",
   "branch": "master",
   "labels": ["tool"],
   "introduction": {


### PR DESCRIPTION
修复了插件 id 不匹配的问题
---

- [x] 我已阅读并检查，此 PR 符合 [贡献指南](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING_zh_cn.md) 中的要求
  I have read and checked that my PR meets the requirements in the [Contributing Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)
