### PR TITLE
添加插件ciki_ecg

### DIFF
--- a/plugins/ciki_ecg/plugin_info.json
+++ b/plugins/ciki_ecg/plugin_info.json
@@ -1,0 +1,15 @@
+{
+    "id": "ciki_ecg",
+    "authors": [
+        {
+            "name": "Crystal0404",
+            "link": "https://github.com/Crystal0404"
+        }
+    ],
+    "repository": "https://github.com/Crystal0404/CikiECG",
+    "branch": "master",
+    "labels": ["management"],
+    "introduction": {
+        "zh_cn": "doc/introduction-zh_cn.md"
+    }
+}


### PR DESCRIPTION
一个针对入门级UPS的低成本停电检测插件, 用于在停电时在UPS有限的供电时间内关闭服务器防止数据损坏

<!-- 在上方撰写您想附加的信息 -->
<!-- Write your own things above -->
---

<!--
- 请确认您的 PR 符合《贡献指南》中的要求，然后勾选下方的复选框，不要修改其它内容
  勾选案例：- [x]
- Please confirm that your pull request meets the Contributing Guidelines, then tick the checkbox below,
  DO NOT MODIFY ANY OTHER CONTENT
  Ticked checkbox sample: - [x]
-->

<!--Checkmate-->
- [x] 我已阅读并检查，此 PR 符合 [贡献指南](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING_zh_cn.md) 中的要求
  I have read and checked that my PR meets the requirements in the [Contributing Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)
