### PR TITLE
添加处理器插件 CommandFuncHandler

### DIFF
--- a/plugins/command_func_handler/plugin_info.json
+++ b/plugins/command_func_handler/plugin_info.json
@@ -1,0 +1,17 @@
+{
+    "id": "command_func_handler",
+    "authors": [
+        {
+            "name": "Mooling0602",
+            "link": "https://github.com/Mooling0602"
+        }
+    ],
+    "repository": "https://github.com/Mooling0602/CommandFuncHandler-MCDR",
+    "branch": "main",
+    "related_path": "src",
+    "labels": ["handler", "api"],
+    "introduction": {
+        "en_us": "../doc/introduction_en_us.md",
+        "zh_cn": "../doc/introduction_zh_cn.md"
+    }
+}


### PR DESCRIPTION
该插件是为 Minecraft 命令和函数设计的 MCDR 服务端处理器。
由于插件提供了 CommandFuncMixin 静态 API，故同时添加了 api 标签。
<!-- 在上方撰写您想附加的信息 -->
<!-- Write your own things above -->
---

<!--
- 请确认您的 PR 符合《贡献指南》中的要求，然后勾选下方的复选框，不要修改其它内容
  勾选案例：- [x]
- Please confirm that your pull request meets the Contributing Guidelines, then tick the checkbox below,
  DO NOT MODIFY ANY OTHER CONTENT
  Ticked checkbox sample: - [x]
-->

<!--Checkmate-->
- [x] 我已阅读并检查，此 PR 符合 [贡献指南](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING_zh_cn.md) 中的要求
  I have read and checked that my PR meets the requirements in the [Contributing Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)
