### PR TITLE
Disable plugin `hitokoto` due to its repository url is not found

### DIFF
--- a/plugins/hitokoto/plugin_info.json
+++ b/plugins/hitokoto/plugin_info.json
@@ -1,4 +1,7 @@
 {
+    "disable": true,
+    "disable_reason": "repository not found",
+
     "id": "hitokoto",
     "authors": [
         {


### PR DESCRIPTION
由于插件仓库中配置的 `hitokoto` 插件的仓库 URL 目前无法访问，已一定程度上影响仓库 CI 运行，故本 PR 将禁用该插件。

As the repository url configured for plugin `hitokoto` in plugin catalogue is no longer reachable, and negatively affecting plugin catalogue CI runs, this pull request will disable this plugin.

禁用后插件将不再在插件仓库及其网站上展示，亦无法通过 MCDR 直接安装。如确需恢复插件有效状态，请另行 PR 移除本次添加的禁用标记，并修改目标插件仓库为有效地址。特此通知原作者。

Disabled plugins will no longer appear in the plugin repository or its website, and cannot be directly installed via MCDR. To re-enable the plugin, please open a separate PR to remove the disable flag introduced here and update the target repository URL to a valid one. Notice is hereby given to the original author. 

原作者 Oringinal author: @gubaiovo 

<!-- 在上方撰写您想附加的信息 -->
<!-- Write your own things above -->
---

<!--
- 请确认您的 PR 符合《贡献指南》中的要求，然后勾选下方的复选框，不要修改其它内容
  勾选案例：- [x]
- Please confirm that your pull request meets the Contributing Guidelines, then tick the checkbox below,
  DO NOT MODIFY ANY OTHER CONTENT
  Ticked checkbox sample: - [x]
-->

<!--Checkmate-->
- [x] 我已阅读并检查，此 PR 符合 [贡献指南](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING_zh_cn.md) 中的要求
  I have read and checked that my PR meets the requirements in the [Contributing Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)
