### PR TITLE
Add plugin: batch_bot_spawn

### DIFF
--- a/plugins/batch_bot_spawn/plugin_info.json
+++ b/plugins/batch_bot_spawn/plugin_info.json
@@ -1,0 +1,16 @@
+{
+  "id": "batch_bot_spawn",
+  "authors": [
+    {
+      "name": "oneIdler",
+      "link": "https://github.com/oneIdler"
+    }
+  ],
+  "repository": "https://github.com/SDK-Minecraft-Server/BatchBotSpawn",
+  "branch": "release",
+  "labels": ["tool"],
+  "introduction": {
+    "en_us": "README_en.md",
+    "zh_cn": "README.md"
+  }
+}


### PR DESCRIPTION
﻿Add [BatchBotSpawn](https://github.com/SDK-Minecraft-Server/BatchBotSpawn) (`batch_bot_spawn`) to the plugin catalogue.

- Repository: https://github.com/SDK-Minecraft-Server/BatchBotSpawn
- Branch: `release`
- Author: [oneIdler](https://github.com/oneIdler)
- Labels: `tool`
- Latest release: v0.2.0 with asset `BatchBotSpawn-v0.2.0.mcdr`
