### PR TITLE
Add curfew_x

### DIFF
--- a/plugins/curfew_x/plugin_info.json
+++ b/plugins/curfew_x/plugin_info.json
@@ -1,0 +1,19 @@
+{
+  "id": "curfew_x",
+  "authors": [
+    {
+      "name": "River_tao",
+      "link": "https://github.com/Rivertao1"
+    }
+  ],
+  "repository": "https://github.com/Rivertao1/CurfewX",
+  "branch": "main",
+  "related_path": ".",
+  "labels": [
+    "management"
+  ],
+  "introduction": {
+    "en_us": "README_en_us.md",
+    "zh_cn": "README.md"
+  }
+}


### PR DESCRIPTION
Add CurfewX, a scheduled server curfew plugin.

- Repository: https://github.com/Rivertao1/CurfewX
- Release: https://github.com/Rivertao1/CurfewX/releases/tag/v0.1.0
- Tested with MCDReforged 2.15.7, Python 3.11.15 and Forge 1.20.1