### PR TITLE
Add plugin: iridium

### DIFF
--- a/plugins/iridium/plugin_info.json
+++ b/plugins/iridium/plugin_info.json
@@ -1,0 +1,17 @@
+{
+	"id": "iridium",
+	"authors": [
+		{
+			"name": "云镜之端/SKYMirror",
+			"link": "https://github.com/HzSKYMirror"
+		}
+	],
+	"repository": "https://github.com/HzSKYMirror/Iridium",
+	"branch": "main",
+	"related_path": ".",
+	"labels": ["tool"],
+	"introduction": {
+		"zh_cn": "README.md",
+		"en_us": "README.md"
+	}
+}


### PR DESCRIPTION
## Plugin

- ID: `iridium`
- Name: Iridium
- Repository: https://github.com/HzSKYMirror/Iridium
- Release: https://github.com/HzSKYMirror/Iridium/releases/tag/v26.9.13
- Labels: `tool`

## Summary

- `!!share`：展示主手物品（悬停完整数据）
- `!!hat`：主手与头部装备互换（需 RCON）
- `!!head [player]`：获取一个玩家头颅
- `!!c <expression>`：游戏内四则运算
- 进服 MOTD 与命令提示

面向 Minecraft 1.7.10+，按版本分支；需要 MCDR >= 2.6.0。
打包插件为 `.mcdr`，GitHub Release 已附带成品。

---

- [x] 我已阅读并检查，此 PR 符合 [贡献指南](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING_zh_cn.md) 中的要求
  I have read and checked that my PR meets the requirements in the [Contributing Guidelines](https://github.com/MCDReforged/PluginCatalogue/blob/master/CONTRIBUTING.md)
